### PR TITLE
FIX Possible keyerror validating ot503 with no stored values

### DIFF
--- a/amoniak/caching/ot503results.py
+++ b/amoniak/caching/ot503results.py
@@ -101,11 +101,13 @@ class OT503Caching(OTCaching):
         " to the month the dailys are considered valid, deleted otherwise
         """
 
-        if period:
-            # Discard other values
+        # If period specified discard all other possible values in values dict
+        if period and period in values:
             values = {period: values[period]}
+        elif period and period not in values:
+            values = {}
 
-        # Different algorism with super validate_contract
+        # Different algorism than super validate_contract:
         # here we will delete al periods not in valid_periods
         valid_periods = []
         for v_period, v_value in values.iteritems():


### PR DESCRIPTION
Arreglat possible keyerror si values no tenia dades del periode (a la crida passa quan no s'han trobat lectures mensuals del mateix)