### PR TITLE
urllib2.HTTPError for new contracts

### DIFF
--- a/amoniak/tasks.py
+++ b/amoniak/tasks.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from datetime import datetime
 import logging
+import urllib2
 
 import libsaas
 
@@ -135,7 +136,7 @@ def enqueue_contracts():
         try:
             last_updated = em.contract(polissa['name']).get()['_updated']
             last_updated = make_local_timestamp(last_updated)
-        except libsaas.http.HTTPError as e:
+        except (libsaas.http.HTTPError, urllib2.HTTPError) as e:
             # A 404 is possible if we delete empowering contracts in insight engine
             # but keep etag in our database.
             # In this case we must force the re-upload as new contract


### PR DESCRIPTION
Also catch `urllib2.HTTPError`

```
INFO:libsaas.executor.urllib2_executor:requesting <Request [GET https://api.empowering.cimne.com/v1/contracts/1002954$│ 28980700, 29044820, 29338148, 29503537, 28567007, 28567000, 28440342, 28683858, 28188062, 28188055, 28761880, 278074
 at 0x7f584e474c50>                                                                                                   │79, 27585537, 27585530, 27755448, 28019138, 28019131, 27575289, 27831692, 27168897, 27168890, 27157648, 27157641, 267
Traceback (most recent call last):                                                                                    │65333, 26573029, 26644093, 26376539, 26376532, 26061427, 26084618, 26084611, 26278378, 26094131, 24644228, 24644221, 
  File "/home/erp/.virtualenvs/openerp5/bin/amoniak", line 9, in <module>                                             │24557743, 24557736, 25536217, 24917921, 24917914, 24900113, 24900106, 25128929, 25128922, 25036025, 25036018, 2542008
    load_entry_point('amoniak==0.7.0', 'console_scripts', 'amoniak')()                                                │7, 24494554, 24494547, 23782696, 23782689, 23644859, 23644852, 22663361, 24236240, 24236233, 24104059, 24104052, 2352
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/click-3.3-py2.7.egg/click/core.py", line 61$│7588, 23527581, 23776242, 23595124, 23595117, 24050810, 23502570, 23502563, 23101365, 22683787, 21470806, 21470799, 2
, in __call__                                                                                                         │1629041, 21972832, 21972825, 21858977, 22140384, 21867566, 21867559, 21292740, 21292733, 21836626, 22257851, 22257844
    return self.main(*args, **kwargs)                                                                                 │, 21580412, 20713581, 20819127, 20819120, 20899585, 20782209, 20782202, 20297606, 20910603, 20200950, 19468519, 19468
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/click-3.3-py2.7.egg/click/core.py", line 59$│512, 19527389, 19176318, 19970034, 19406695, 19406688, 19955537, 19286330, 19286323, 19971644, 19971637, 19808908, 19
, in main                                                                                                             │973793, 18907994, 18822265, 18822258, 18661664, 18661657, 18679948, 18679941, 18369246, 18546857, 18584146, 18027240,
    rv = self.invoke(ctx)                                                                                             │ 17531192, 16770117, 16770110, 17519278, 17297581, 17476991, 17476984, 16712556, 16659839, 16905924, 16905917, 173720
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/click-3.3-py2.7.egg/click/core.py", line 936│12, 16956765, 16956758, 17009440, 17691569, 16193135, 16376178, 16249695, 16249688, 16483887, 16427180, 16161383, 161
, in invoke                                                                                                           │61376, 15715854, 15715847, 15772533, 15772526, 15516676, 15410794, 15596287, 15596280, 14451227, 14339990, 14384622, 
    return _process_result(sub_ctx.command.invoke(sub_ctx))                                                           │14384615, 14703570, 14703563, 14518763, 14518756, 15235122, 14605311, 13782706, 13782699, 13952645, 14607166, 1490105
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/click-3.3-py2.7.egg/click/core.py", line 782│4, 14472787, 14810292, 13865082, 13865075, 13185123, 13541717, 13541710, 13329953, 13329946, 13408857, 13408850, 1287
, in invoke                                                                                                           │7403, 12526633, 12526626, 11848732, 11720954, 11720947, 11420297, 12388397, 12388390, 11760644, 12805191, 12889576, 1
    return ctx.invoke(self.callback, **ctx.params)                                                                    │1479461, 11479454, 12802300, 12681081, 11268754, 11559002, 11983559, 11288459, 11288452, 11476542, 11306680, 12197535
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/click-3.3-py2.7.egg/click/core.py", line 416│, 12197528, 10842174, 11006772, 11006765, 10634778, 10634771, 10639587, 10639580, 10979745, 10979738, 10536561, 10767
, in invoke                                                                                                           │057, 10767050, 10742676, 10742669, 10856671, 10856664, 11020940, 11020933, 9898980, 9916389, 9975854, 9975847, 993905
    return callback(*args, **kwargs)                                                                                  │5, 9939048, 9229339, 9402386, 9402379, 9384256, 9384249, 9267433, 9371789, 8715567, 8715560, 8970626, 8970619, 231214
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/amoniak-0.7.0-py2.7.egg/amoniak/runner.py", │2, 3707858, 5209015, 5209008, 6115529, 6115522, 6279525, 7130949, 7130942, 3682693, 2414475, 1304968, 7899815, 789980
line 45, in enqueue_contracts                                                                                         │8, 5945156, 5945149, 2790991, 6058661, 6058654, 8167579, 8167572, 2021929, 3020745, 7196021, 7196014, 4037894, 403788
    tasks.enqueue_contracts()                                                                                         │7, 8519140, 8519133, 7829003, 7828996, 6604885, 6970292, 8120581, 8120574, 5449297, 7872529, 7872522, 4371773, 223794
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/amoniak-0.7.0-py2.7.egg/amoniak/tasks.py", l│2, 3318378, 8327592, 8327585, 8310246, 8310239, 8439956, 8439949, 4637955, 8170624, 8170617, 4572330, 4688936, 468892
ine 136, in enqueue_contracts                                                                                         │9, 5624360, 5624353, 2577246, 6729093, 6729086, 5707016, 3135216, 1732738, 4990468, 4990461, 4811303, 4811296, 441713
    last_updated = em.contract(polissa['name']).get()['_updated']                                                     │3, 7854063, 7854056, 4453218, 5189793, 8323210, 8323203, 3884370, 8333451, 8333444, 488992, 6992930, 6992923, 788018,
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/libsaas/services/base.py", line 95, in wrapp│ 788011, 2836575, 2836568, 1595958]) (de5566b0-4ece-4073-ba5d-a50edc4861d2)
ed                                                                                                                    │Raven is not configured (logging is disabled). Please see the documentation for more information.
    return current.process(request, parser)                                                                           │11:09:56 Raven is not configured (logging is disabled). Please see the documentation for more information.
  File "/home/erp/.virtualenvs/openerp5/local/lib/python2.7/site-packages/libsaas/executors/urllib2_executor.py", line│11:09:57 Enviant de 2012-04-08 00:00:00 (id:1595958) a 2013-08-20 00:00:00 (id:50568798)
 73, in __call__                                                                                                      │11:09:58 Mesures transformades en 0:00:01.343616
    resp = opener.open(req)                                                                                           │11:09:58 requesting <Request [POST https://api.empowering.cimne.com/v1/amon_measures] at 0x7f975e75a050>
  File "/usr/lib/python2.7/urllib2.py", line 410, in open                                                             │
    response = meth(req, response)                                                                                    ├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  File "/usr/lib/python2.7/urllib2.py", line 523, in http_response                                                    │63273742, 62717396, 62717389, 62579300, 62590577, 62405560, 62405553, 62137593, 62137586, 61543867, 61543860, 6184198
    'http', request, response, code, msg, hdrs)                                                                       │3, 61744249, 61361279, 61100991, 61100984, 61078619, 61078612, 61099073, 60265002, 60264995, 59845317, 59845310, 6040
  File "/usr/lib/python2.7/urllib2.py", line 448, in error                                                            │7452, 60407445, 60037334, 60048779, 60048772, 59883936, 59146563, 59146556, 59341359, 59246593, 59246586, 59536197, 5
    return self._call_chain(*args)                                                                                    │9352062, 58599541, 58395701, 58395694, 58549771, 58549764, 58571520, 58571513, 57774850, 57774843, 57677970, 57223320
  File "/usr/lib/python2.7/urllib2.py", line 382, in _call_chain                                                      │, 57792042, 57792035, 57436806, 56851795, 56851788, 57005830, 57005823, 57109640, 56875336, 56875329, 56005845, 56308
    result = func(*args)                                                                                              │672, 56308665, 56197232, 55607475, 55607468, 55696641, 55047818, 55093605, 55093598, 55345185, 55345178, 54623422, 54
  File "/usr/lib/python2.7/urllib2.py", line 531, in http_error_default                                               │423530, 54423523, 54014072, 54706925, 53871776, 54411826, 54411819, 54352361, 53465615, 53719309, 53719302, 53297167,
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)                                                          │ 53297160, 53255608, 53754799, 53754792, 52364354, 53360356, 53360349, 53211291, 52758853, 51880717, 52126508, 521265
urllib2.HTTPError: HTTP Error 404: NOT FOUND 
```