### PR TITLE
Update empowering requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ERPpeek==1.6
-empowering==0.7.0
+empowering>=0.15.4
 modeldict==0.5.0
 pymongo==2.7.2
 raven==5.0.0


### PR DESCRIPTION
In a production server there is installed empowering==0.15.4 with https://github.com/Som-Energia/amoniak that is ahead of https://github.com/gisce/amoniak. Empowering 0.7.0 is using [old marshmallow fields](https://github.com/gisce/empowering/blob/v0.7.0/empowering/models.py#L59) from old beta version 2.0.0b2 so the requirements must be updated because it is not compatible with https://github.com/gisce/sii requirements