### PR TITLE
Correcciones en el envío de precios

### DIFF
--- a/amoniak/tasks.py
+++ b/amoniak/tasks.py
@@ -26,7 +26,7 @@ def enqueue_tariffs(tariffs=None):
     search_params = []
     if tariffs:
         search_params.append(('name', 'in', tariffs))
-    tids = c.ProductPricelist.search(search_params)
+    tids = c.ProductPricelist.search(search_params, context={'active_test': False})
     to_q = []
     for pricelist in c.ProductPricelist.browse(tids):
         for tatr in pricelist.tarifes_atr_compatibles:
@@ -435,12 +435,14 @@ def push_tariffs(tariffs):
     a = AmonConverter(c)
     result = a.tariff_to_amon(*tariffs)
     with setup_empowering_api() as em:
-        try:
-            print(result)
-            em.tariffs().create(result)
-        except urllib2.HTTPError as err:
-            print(err.read())
-            raise
+        for r in result:
+            try:
+                print(r)
+                em.tariffs().create(r)
+            except urllib2.HTTPError as err:
+                print(err.read())
+                raise
+
 
 @job(setup_queue(name='indexeds'), connection=setup_redis(), timeout=3600)
 @sentry.capture_exceptions


### PR DESCRIPTION
#### Problemas

- Las tarifas están enviando sólo un objeto por lista de precios.
- Las fechas del intervalo de vigencia de los precios se solapan.

#### Actuaciones

- Se mandará un objeto por cada versión de precios de cada lista de precios.
- Las fechas se mandarán con hora para que no se solapen precios.
  - La hora de inicio será a la hora `01:00:00` del día del alta.
  - La hora de fin, en caso de informarse, será a la hora `00:00:00` del día siguiente a la baja.

#### Relacionado

- https://api.beedataanalytics.com/v1/docs

![Captura de pantalla de 2022-10-26 16-29-16](https://user-images.githubusercontent.com/49635897/198053870-051f7a4c-7b15-4376-9a86-db5a0d1f6824.png)
