### PR TITLE
Añadir el margen al nombre de los históricos de tarifas a precio indexado

### DIFF
--- a/amoniak/amon.py
+++ b/amoniak/amon.py
@@ -473,7 +473,8 @@ class AmonConverter(object):
             for k, _ in history_fields:
                 contract[k] = []
             modcon_fields = [
-                'data_inici', 'data_final', 'llista_preu', 'tarifa', 'potencia'
+                'data_inici', 'data_final', 'llista_preu', 'tarifa', 'potencia',
+                'mode_facturacio', 'coeficient_d', 'coeficient_k'
             ]
             mcon_activa = polissa['modcontractual_activa'][0]
             for modcon in O.GiscedataPolissaModcontractual.read(polissa['modcontractuals_ids'], modcon_fields):

--- a/amoniak/amon.py
+++ b/amoniak/amon.py
@@ -478,10 +478,17 @@ class AmonConverter(object):
             mcon_activa = polissa['modcontractual_activa'][0]
             for modcon in O.GiscedataPolissaModcontractual.read(polissa['modcontractuals_ids'], modcon_fields):
                 mod_tarifa_atr = modcon['tarifa'][1]
+
+                if modcon['mode_facturacio'] == 'index':
+                    fee = modcon['coeficient_d'] + modcon['coeficient_k']
+                    tariff_cost_id = '{} - {}'.format(modcon['llista_preu'][1], fee)
+                else:
+                    tariff_cost_id = modcon['llista_preu'][1]
+
                 contract['tariffCostHistory'].append({
                     'dateStart': make_utc_timestamp(modcon['data_inici']),
                     'dateEnd': make_utc_timestamp(modcon['data_final']),
-                    'tariffCostId': modcon['llista_preu'][1]
+                    'tariffCostId': tariff_cost_id
                 })
                 contract['tariffHistory'].append({
                     'dateStart': make_utc_timestamp(modcon['data_inici']),


### PR DESCRIPTION
## Objetivos

- Cuando se manda una tarifa a precio indexado, esta debe mostrar su `fee` (margen) tras el nombre, no sólo para la tarifa actual sino para sus históricas si el contrato era indexado en ese momento.
