### PR TITLE
Sincronización de "etags" al enviar información de contratos si es necesario

### DIFF
--- a/amoniak/tasks.py
+++ b/amoniak/tasks.py
@@ -197,6 +197,10 @@ def enqueue_contracts(contracts=None, force=False):
             with setup_empowering_api() as em:
                 last_updated = em.contract(polissa['name']).get()['_updated']
                 last_updated = make_local_timestamp(last_updated)
+                etag_beedata = em.contract(polissa['name']).get()['_etag']
+                # Update etag in ERP if it changed
+                if etag_beedata != polissa['etag']:
+                    O.GiscedataPolissa.write(polissa['id'], {'etag': etag_beedata})
         except (libsaas.http.HTTPError, urllib2.HTTPError) as e:
             # A 404 is possible if we delete empowering contracts in insight engine
             # but keep etag in our database.

--- a/amoniak/tasks.py
+++ b/amoniak/tasks.py
@@ -200,6 +200,7 @@ def enqueue_contracts(contracts=None, force=False):
                 etag_beedata = em.contract(polissa['name']).get()['_etag']
                 # Update etag in ERP if it changed
                 if etag_beedata != polissa['etag']:
+                    logger.info('Contract {} changed "etag". Resynced "etag" from API.'.format(polissa['name']))
                     O.GiscedataPolissa.write(polissa['id'], {'etag': etag_beedata})
         except (libsaas.http.HTTPError, urllib2.HTTPError) as e:
             # A 404 is possible if we delete empowering contracts in insight engine


### PR DESCRIPTION
## Objetivo

- Cuando se vaya a comunicar información contractual a la API de BEEDATA, si el `etag` que consta en la API no coincide con el que consta en el ERP, este se actualiza antes de realizar el envío.
