### PR TITLE
Se ha implementado la opción de enviar tarifas a precio indexado específicas

### DIFF
--- a/amoniak/runner.py
+++ b/amoniak/runner.py
@@ -99,11 +99,12 @@ def enqueue_contract(contracts, force):
 
 @amoniak.command()
 @click.option('--force', default=False, is_flag=True)
+@click.argument('--partial_name_list', default=False, is_flag=True)
 @click.argument('wreport', nargs=-1)
-def enqueue_indexed(force, wreport):
+def enqueue_indexed(force, partial_name_list, wreport):
     logger = logging.getLogger('amon')
     logger.info('Enqueuing indexed data')
-    tasks.enqueue_indexed(force=force, wreport=wreport)
+    tasks.enqueue_indexed(force=force, wreport=wreport, partial_name_list=partial_name_list)
 
 if __name__ == '__main__':
     amoniak(obj={})

--- a/amoniak/runner.py
+++ b/amoniak/runner.py
@@ -99,12 +99,12 @@ def enqueue_contract(contracts, force):
 
 @amoniak.command()
 @click.option('--force', default=False, is_flag=True)
-@click.argument('--partial_name_list', default=False, is_flag=True)
+@click.argument('--pricelist-name', default=False)
 @click.argument('wreport', nargs=-1)
-def enqueue_indexed(force, partial_name_list, wreport):
+def enqueue_indexed(force, pricelist_name, wreport):
     logger = logging.getLogger('amon')
     logger.info('Enqueuing indexed data')
-    tasks.enqueue_indexed(force=force, wreport=wreport, partial_name_list=partial_name_list)
+    tasks.enqueue_indexed(force=force, wreport=wreport, pricelist_name=pricelist_name)
 
 if __name__ == '__main__':
     amoniak(obj={})

--- a/amoniak/runner.py
+++ b/amoniak/runner.py
@@ -99,12 +99,12 @@ def enqueue_contract(contracts, force):
 
 @amoniak.command()
 @click.option('--force', default=False, is_flag=True)
-@click.argument('--pricelist-name', default=False)
+@click.option('--pricelist', default=False)
 @click.argument('wreport', nargs=-1)
-def enqueue_indexed(force, pricelist_name, wreport):
+def enqueue_indexed(force, pricelist, wreport):
     logger = logging.getLogger('amon')
     logger.info('Enqueuing indexed data')
-    tasks.enqueue_indexed(force=force, wreport=wreport, pricelist_name=pricelist_name)
+    tasks.enqueue_indexed(force=force, pricelist=pricelist, wreport=wreport)
 
 if __name__ == '__main__':
     amoniak(obj={})

--- a/amoniak/tasks.py
+++ b/amoniak/tasks.py
@@ -241,7 +241,7 @@ def enqueue_contracts(contracts=None, force=False):
             push_contracts.delay([polissa['id']])
 
 
-def enqueue_indexed(bucket=1, force=False, wreport=False, pricelist_name=False):
+def enqueue_indexed(bucket=1, force=False, pricelist=False, wreport=False):
     """Busquem els grups indexats formats per llista preu + FEE que coincideixin
     Recuperem l'ultima data publicada per saber d'es d'on pujar
     Si l'agrupació no s'ha pujat mai, busquem factures i pujem desde la data més petita
@@ -258,8 +258,9 @@ def enqueue_indexed(bucket=1, force=False, wreport=False, pricelist_name=False):
     for pol in O.GiscedataPolissa.read(pids, ['llista_preu', 'coeficient_d', 'coeficient_k', 'name', 'tarifa']):
         fee = pol['coeficient_d'] + pol['coeficient_k']
         llprice = pol['llista_preu'][1]
-        if pricelist_name:
-            if pricelist_name not in llprice:
+        # If pricelist name is specified, filter
+        if pricelist:
+            if pricelist not in llprice:
                 continue
         tarifa = pol['tarifa'][1]
         key = (tarifa, '{} - {}'.format(llprice, fee))

--- a/amoniak/tasks.py
+++ b/amoniak/tasks.py
@@ -241,7 +241,7 @@ def enqueue_contracts(contracts=None, force=False):
             push_contracts.delay([polissa['id']])
 
 
-def enqueue_indexed(bucket=1, force=False, wreport=False):
+def enqueue_indexed(bucket=1, force=False, wreport=False, partial_name_list=False):
     """Busquem els grups indexats formats per llista preu + FEE que coincideixin
     Recuperem l'ultima data publicada per saber d'es d'on pujar
     Si l'agrupació no s'ha pujat mai, busquem factures i pujem desde la data més petita
@@ -258,6 +258,9 @@ def enqueue_indexed(bucket=1, force=False, wreport=False):
     for pol in O.GiscedataPolissa.read(pids, ['llista_preu', 'coeficient_d', 'coeficient_k', 'name', 'tarifa']):
         fee = pol['coeficient_d'] + pol['coeficient_k']
         llprice = pol['llista_preu'][1]
+        if partial_name_list:
+            if partial_name_list not in llprice:
+                continue
         tarifa = pol['tarifa'][1]
         key = (tarifa, '{} - {}'.format(llprice, fee))
         if key not in indexed_grouppeds:

--- a/amoniak/tasks.py
+++ b/amoniak/tasks.py
@@ -241,7 +241,7 @@ def enqueue_contracts(contracts=None, force=False):
             push_contracts.delay([polissa['id']])
 
 
-def enqueue_indexed(bucket=1, force=False, wreport=False, partial_name_list=False):
+def enqueue_indexed(bucket=1, force=False, wreport=False, pricelist_name=False):
     """Busquem els grups indexats formats per llista preu + FEE que coincideixin
     Recuperem l'ultima data publicada per saber d'es d'on pujar
     Si l'agrupació no s'ha pujat mai, busquem factures i pujem desde la data més petita
@@ -258,8 +258,8 @@ def enqueue_indexed(bucket=1, force=False, wreport=False, partial_name_list=Fals
     for pol in O.GiscedataPolissa.read(pids, ['llista_preu', 'coeficient_d', 'coeficient_k', 'name', 'tarifa']):
         fee = pol['coeficient_d'] + pol['coeficient_k']
         llprice = pol['llista_preu'][1]
-        if partial_name_list:
-            if partial_name_list not in llprice:
+        if pricelist_name:
+            if pricelist_name not in llprice:
                 continue
         tarifa = pol['tarifa'][1]
         key = (tarifa, '{} - {}'.format(llprice, fee))


### PR DESCRIPTION
## Objetivos

- Se ha implementado el flag `pricelist` en el envío de datos de tarifas indexadas.
- Si se pasa valor al parámetro `pricelist`, se obtendrán y publicarán únicamnete los datos de tarifas indexadas de los contratos cuya lista de precios contenga la palabra consecuente al "flag" `pricelist`.
